### PR TITLE
Add rotation movements

### DIFF
--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -100,8 +100,9 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
 
     // Move the body.
     hexapod_model_->move_body_in_body_frame(cycle_distance_meters_global_frame_x * phase_time_ratio, cycle_distance_meters_global_frame_y * phase_time_ratio, 0);
+    // TODO: Is rotating the body here correct? Will it mess with the set_foot_position_in_body_frame later?
     if (angular_speed_magnitude >= angular_deadzone_) {
-        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate);
+        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
     }
 
 
@@ -119,7 +120,6 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
 
         if (angular_speed_magnitude >= angular_deadzone_) {
             // To add rotation, find vector perpendicular to the center_to_feet vector.
-            // There will be two perpendicular, choose the one that matches the direction.
             Vector2f center_to_feet(
                 feet_positions_in_body_frame.foot[i].x,
                 feet_positions_in_body_frame.foot[i].y);

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -14,6 +14,7 @@ using namespace Eigen;
 
 GaitPlanner::GaitPlanner(std::shared_ptr<HexapodModel> model, float publish_rate) : hexapod_model_(model), publish_rate_(publish_rate){
     ros::param::get("GAIT_PERIOD_DISTANCE", gait_period_distance_);
+    ros::param::get("GAIT_PERIOD_ROTATION", gait_period_rotation_);
     ros::param::get("LEG_LIFT_HEIGHT", leg_lift_height_);
 
     // Initialize gait.
@@ -41,11 +42,13 @@ void GaitPlanner::reset_state() {
 void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
     // Calculate the magnitude of the twist linear speed.
     float linear_speed_magnitude = sqrt(pow(twist.linear.x, 2) + pow(twist.linear.y, 2));
+    float angular_speed_magnitude = abs(twist.angular.x);
+
     float phase_time_ratio = 1 - gait_->get_duty_factor();
     float cycle_distance_meters_global_frame_x = 0.f;
     float cycle_distance_meters_global_frame_y = 0.f;
 
-    if (linear_speed_magnitude >= deadzone_) {
+    if (linear_speed_magnitude >= linear_deadzone_ || angular_speed_magnitude >= angular_deadzone_) {
         is_travelling_ = true;
         if (!was_travelling_) {
             period_cycle_ = 0;
@@ -55,10 +58,12 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
 
         // Each gait period has many cycles depending on the gait mode. We can calculate the distance to be traversed
         // in one cycle.
-        float distance_per_cycle = gait_period_distance_ * phase_time_ratio;
+        // TODO: Introducing rotation, distance to be traversed in one cycle may be different for each leg
+        float distance_per_cycle = (gait_period_distance_) * phase_time_ratio;
 
         // (speed / publish rate) is the distance to be traversed in one compute frame (cycle).
         // This cycle is not the same as the gait cycle.
+        // TODO: Speed magnitude needs to include the angular speed
         period_cycle_length_ = distance_per_cycle / (linear_speed_magnitude / publish_rate_);
 
         if (previous_period_cycle_length_ != 0) {
@@ -78,7 +83,7 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         cycle_distance_meters_global_frame_y = cycle_distance_meters_global_frame[1];
     } else {
         is_travelling_ = false;
-        // Force extra cycle here to get period of 0 so legs are are touching the ground.
+        // Force extra cycle here to get period of 0 so legs are touching the ground.
         if (was_travelling_ || force_extra_period_) {
             previous_period_cycle_length_ = period_cycle_length_;
             period_cycle_length_ = reset_leg_period_cycle_length_;
@@ -98,11 +103,34 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
     // Get default feet/legs positions
     hexapod_msgs::FeetPositions default_feet_positions_in_body_frame = hexapod_model_->get_initial_feet_positions_in_body_frame();
 
+    // Get current feet/legs positions in body frame
+    hexapod_msgs::FeetPositions feet_positions_in_body_frame = hexapod_model_->get_feet_positions_in_body_frame();
+
     // Move the legs.
     for (int i = 0; i < 6; i++) {
         float new_x = default_feet_positions_in_body_frame.foot[i].x;
         float new_y = default_feet_positions_in_body_frame.foot[i].y;
         float new_z = default_feet_positions_in_body_frame.foot[i].z;
+
+        if (angular_speed_magnitude >= angular_deadzone_) {
+            // To add rotation, find vector perpendicular to the center_to_feet vector.
+            // There will be two perpendicular, choose the one that matches the direction.
+            Vector2f center_to_feet(
+                feet_positions_in_body_frame.foot[i].x,
+                feet_positions_in_body_frame.foot[i].y);
+
+            Vector2f perpendicular(0.f, 0.f);
+            if (twist.angular.x > 0) {
+                perpendicular = get_perpendicular_counterclockwise(center_to_feet);
+            } else {
+                perpendicular = get_perpendicular_clockwise(center_to_feet);
+            }
+
+            // TODO: Scale the perpendicular vector by how much we want to rotate.
+
+            cycle_distance_meters_global_frame_x += perpendicular[0];
+            cycle_distance_meters_global_frame_y += perpendicular[0];
+        }
 
         if (gait_seq_[i] == 1) {
             new_x += cycle_distance_meters_global_frame_x * ((-1 * phase_time_ratio * gait_->get_sequence_index() * (period_cycle_length_)) + ((1  - phase_time_ratio) * (period_cycle_ + 1)));
@@ -148,4 +176,12 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
     if (is_travelling_) {
         was_travelling_ = true;
     }
+}
+
+Vector2f GaitPlanner::get_perpendicular_clockwise(const Vector2f &vec) const {
+    return Vector2f(vec[1], -vec[0]).normalized();
+}
+
+Vector2f GaitPlanner::get_perpendicular_counterclockwise(const Vector2f &vec) const {
+    return Vector2f(-vec[1], vec[0]).normalized();
 }

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -71,7 +71,7 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         float rotation_component = rotation_per_cycle / (angular_speed_magnitude / publish_rate_);
 
         period_cycle_length_ = angular_speed_magnitude >= angular_deadzone_ ? rotation_component : dist_component;
-        is_translating_ = linear_speed_magnitude >= linear_deadzone_;
+        was_translating_ = linear_speed_magnitude >= linear_deadzone_;
 
         if (previous_period_cycle_length_ != 0) {
             period_cycle_ = round((static_cast<float>(period_cycle_) / previous_period_cycle_length_) * period_cycle_length_);

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -64,9 +64,16 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
 
         // (speed / publish rate) is the distance to be traversed in one compute frame (cycle).
         // This cycle is not the same as the gait cycle.
-        period_cycle_length_ = std::max(
-                distance_per_cycle / (linear_speed_magnitude / publish_rate_),
-                rotation_per_cycle / (angular_speed_magnitude / publish_rate_));
+        float dist_component = distance_per_cycle / (linear_speed_magnitude / publish_rate_);
+        float rotation_component = rotation_per_cycle / (angular_speed_magnitude / publish_rate_);
+
+        if (angular_speed_magnitude >= angular_deadzone_ && linear_speed_magnitude >= linear_deadzone_) {
+            period_cycle_length_ = std::max(dist_component, rotation_component);
+        } else if (linear_speed_magnitude >= linear_deadzone_) {
+            period_cycle_length_ = dist_component;
+        } else {
+            period_cycle_length_ = rotation_component;
+        }
 
         if (previous_period_cycle_length_ != 0) {
             period_cycle_ = round((static_cast<float>(period_cycle_) / previous_period_cycle_length_) * period_cycle_length_);

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -110,13 +110,13 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         }
     }
 
-//    // TODO: Is rotating the body here correct? Will it mess with the set_foot_position_in_body_frame later?
-//    if (angular_speed_magnitude >= angular_deadzone_) {
-//        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
-//    }
-
     // Move the body.
     hexapod_model_->move_body_in_body_frame(cycle_distance_meters_local_frame_x * phase_time_ratio, cycle_distance_meters_local_frame_y * phase_time_ratio, 0);
+
+    // TODO: Make this work. Robot rotates fine without this.
+/*    if (angular_speed_magnitude >= angular_deadzone_) {
+        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
+    }*/
 
     // Get default feet/legs positions
     hexapod_msgs::FeetPositions default_feet_positions_in_body_frame = hexapod_model_->get_initial_feet_positions_in_body_frame();
@@ -144,7 +144,6 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
 
             cycle_distance_from_rotation_meters_local_frame_x = perpendicular[0];
             cycle_distance_from_rotation_meters_local_frame_y = perpendicular[1];
-            // ROS_INFO("Leg %d: x: %f, y: %f | p_x: %f, p_y: %f", i, cycle_distance_from_rotation_meters_local_frame_x, cycle_distance_from_rotation_meters_local_frame_y, perpendicular[0], perpendicular[1]);
         }
 
         float cycle_total_distance_meters_local_frame_x =
@@ -187,7 +186,6 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         }
         hexapod_model_->set_foot_position_in_body_frame(i, new_x, new_y, new_z);
     }
-    // ROS_INFO("-----");
 
     period_cycle_++;
     if (period_cycle_ == period_cycle_length_) {

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -42,7 +42,7 @@ void GaitPlanner::reset_state() {
 void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
     // Calculate the magnitude of the twist linear speed.
     float linear_speed_magnitude = sqrt(pow(twist.linear.x, 2) + pow(twist.linear.y, 2));
-    float angular_speed_magnitude = abs(twist.angular.x);
+    float angular_speed_magnitude = abs(twist.angular.z);
     float angular_distance_per_rate = angular_speed_magnitude / publish_rate_;
 
     float phase_time_ratio = 1 - gait_->get_duty_factor();

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -62,22 +62,18 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
 
         // Each gait period has many cycles depending on the gait mode. We can calculate the distance to be traversed
         // in one cycle.
-        float rotation_per_cycle = (gait_period_rotation_) * phase_time_ratio;
-        float distance_per_cycle = (gait_period_distance_) * phase_time_ratio;
-
         // (speed / publish rate) is the distance to be traversed in one compute frame (cycle).
         // This cycle is not the same as the gait cycle.
-        float dist_component = distance_per_cycle / (linear_speed_magnitude / publish_rate_);
-        float rotation_component = rotation_per_cycle / (angular_speed_magnitude / publish_rate_);
-
         if (angular_speed_magnitude >= angular_deadzone_) {
-            period_cycle_length_ = rotation_component;
+            float rotation_per_cycle = (gait_period_rotation_) * phase_time_ratio;
+            period_cycle_length_ = rotation_per_cycle / (angular_speed_magnitude / publish_rate_);;
             was_rotating_ = true;
         } else {
             // Get the distances in x and y-axis to move for one cycle (frame)
             cycle_distance_meters_local_frame_x = twist.linear.x / publish_rate_;
             cycle_distance_meters_local_frame_y = twist.linear.y / publish_rate_;
-            period_cycle_length_ = dist_component;
+            float distance_per_cycle = (gait_period_distance_) * phase_time_ratio;
+            period_cycle_length_ = distance_per_cycle / (linear_speed_magnitude / publish_rate_);;
             was_rotating_ = false;
         }
 

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -110,19 +110,19 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         }
     }
 
-    // TODO: Make this work. Robot rotates fine without this.
-    if (angular_speed_magnitude >= angular_deadzone_) {
-        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
-    }
-
-    // Move the body.
-    hexapod_model_->move_body_in_body_frame(cycle_distance_meters_local_frame_x * phase_time_ratio, cycle_distance_meters_local_frame_y * phase_time_ratio, 0);
-
     // Get default feet/legs positions
     hexapod_msgs::FeetPositions default_feet_positions_in_body_frame = hexapod_model_->get_initial_feet_positions_in_body_frame();
 
     // Get current feet/legs positions
     hexapod_msgs::FeetPositions feet_positions_in_body_frame = hexapod_model_->get_feet_positions_in_body_frame();
+
+/*    // TODO: Make this work. Robot rotates fine without this.
+    if (angular_speed_magnitude >= angular_deadzone_) {
+        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
+    }*/
+
+    // Move the body.
+    hexapod_model_->move_body_in_body_frame(cycle_distance_meters_local_frame_x * phase_time_ratio, cycle_distance_meters_local_frame_y * phase_time_ratio, 0);
 
     // Move the legs.
     for (int i = 0; i < 6; i++) {
@@ -189,18 +189,6 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         }
         hexapod_model_->set_foot_position_in_body_frame(i, new_x, new_y, new_z);
     }
-
-/*    hexapod_msgs::FeetPositions ft = hexapod_model_->get_feet_positions();
-
-    ROS_INFO("--------------");
-    for (int i = 0; i < 6; i++) {
-        ROS_INFO("Leg %d: x: %f, y: %f, z: %f", i, ft.foot[i].x, ft.foot[i].y, ft.foot[i].z);
-    }
-    ROS_INFO("ROLL: %f", hexapod_model_->get_body_roll());
-    Matrix3f mat = hexapod_model_->get_body_rot_mat();
-    IOFormat CleanFmt(4, 0, ", ", "\n", "[", "]");
-    std::cout << mat.format(CleanFmt) << std::endl;*/
-
 
     period_cycle_++;
     if (period_cycle_ == period_cycle_length_) {

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -121,7 +121,7 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
                 feet_positions_in_body_frame.foot[i].y);
 
             Vector2f perpendicular(0.f, 0.f);
-            if (twist.angular.x > 0.f) {
+            if (twist.angular.z > 0.f) {
                 perpendicular = get_perpendicular_clockwise(center_to_feet);
             } else {
                 perpendicular = get_perpendicular_counterclockwise(center_to_feet);

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -110,13 +110,13 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         }
     }
 
+    // TODO: Make this work. Robot rotates fine without this.
+    if (angular_speed_magnitude >= angular_deadzone_) {
+        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
+    }
+
     // Move the body.
     hexapod_model_->move_body_in_body_frame(cycle_distance_meters_local_frame_x * phase_time_ratio, cycle_distance_meters_local_frame_y * phase_time_ratio, 0);
-
-    // TODO: Make this work. Robot rotates fine without this.
-/*    if (angular_speed_magnitude >= angular_deadzone_) {
-        hexapod_model_->set_body_roll(hexapod_model_->get_body_roll() + angular_distance_per_rate * phase_time_ratio);
-    }*/
 
     // Get default feet/legs positions
     hexapod_msgs::FeetPositions default_feet_positions_in_body_frame = hexapod_model_->get_initial_feet_positions_in_body_frame();
@@ -189,6 +189,18 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         }
         hexapod_model_->set_foot_position_in_body_frame(i, new_x, new_y, new_z);
     }
+
+/*    hexapod_msgs::FeetPositions ft = hexapod_model_->get_feet_positions();
+
+    ROS_INFO("--------------");
+    for (int i = 0; i < 6; i++) {
+        ROS_INFO("Leg %d: x: %f, y: %f, z: %f", i, ft.foot[i].x, ft.foot[i].y, ft.foot[i].z);
+    }
+    ROS_INFO("ROLL: %f", hexapod_model_->get_body_roll());
+    Matrix3f mat = hexapod_model_->get_body_rot_mat();
+    IOFormat CleanFmt(4, 0, ", ", "\n", "[", "]");
+    std::cout << mat.format(CleanFmt) << std::endl;*/
+
 
     period_cycle_++;
     if (period_cycle_ == period_cycle_length_) {

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -53,7 +53,7 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         is_translating_ = linear_speed_magnitude >= linear_deadzone_;
         is_travelling_ = true;
 
-        if (!was_travelling_ || was_translating_ && !is_translating_ || !was_translating_ && is_translating_) {
+        if (!was_travelling_ || (was_translating_ && !is_translating_) || (!was_translating_ && is_translating_)) {
             period_cycle_ = 0;
         }
 

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -71,7 +71,7 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         float rotation_component = rotation_per_cycle / (angular_speed_magnitude / publish_rate_);
 
         period_cycle_length_ = angular_speed_magnitude >= angular_deadzone_ ? rotation_component : dist_component;
-        was_travelling_ = linear_speed_magnitude >= linear_deadzone_;
+        is_translating_ = linear_speed_magnitude >= linear_deadzone_;
 
         if (previous_period_cycle_length_ != 0) {
             period_cycle_ = round((static_cast<float>(period_cycle_) / previous_period_cycle_length_) * period_cycle_length_);

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -101,9 +101,6 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
     // Get default feet/legs positions
     hexapod_msgs::FeetPositions default_feet_positions_in_body_frame = hexapod_model_->get_initial_feet_positions_in_body_frame();
 
-    // Get current feet/legs positions in body frame
-    hexapod_msgs::FeetPositions feet_positions_in_body_frame = hexapod_model_->get_feet_positions_in_body_frame();
-
     // Move the legs.
     for (int i = 0; i < 6; i++) {
         float new_x = default_feet_positions_in_body_frame.foot[i].x;

--- a/src/gait_planner.cpp
+++ b/src/gait_planner.cpp
@@ -121,6 +121,9 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
     // Get default feet/legs positions
     hexapod_msgs::FeetPositions default_feet_positions_in_body_frame = hexapod_model_->get_initial_feet_positions_in_body_frame();
 
+    // Get current feet/legs positions
+    hexapod_msgs::FeetPositions feet_positions_in_body_frame = hexapod_model_->get_feet_positions_in_body_frame();
+
     // Move the legs.
     for (int i = 0; i < 6; i++) {
         float new_x = default_feet_positions_in_body_frame.foot[i].x;
@@ -133,8 +136,8 @@ void GaitPlanner::update_model(geometry_msgs::Twist& twist) {
         if (angular_speed_magnitude >= angular_deadzone_) {
             // To add rotation, find vector perpendicular to the center_to_feet vector.
             Vector2f center_to_feet(
-                    default_feet_positions_in_body_frame.foot[i].x,
-                    default_feet_positions_in_body_frame.foot[i].y);
+                    feet_positions_in_body_frame.foot[i].x,
+                    feet_positions_in_body_frame.foot[i].y);
 
             Vector2f perpendicular = get_perpendicular_clockwise(center_to_feet);
 

--- a/src/gait_planner.h
+++ b/src/gait_planner.h
@@ -45,6 +45,7 @@ private:
     bool was_travelling_{false};
     bool is_travelling_{false};
     bool force_extra_period_{false};
+    bool is_translating_{true};
 
     // Loads from parameter server
     float gait_period_distance_;

--- a/src/gait_planner.h
+++ b/src/gait_planner.h
@@ -40,13 +40,22 @@ private:
     int period_cycle_{0};
     int reset_leg_period_cycle_length_{30};
     float publish_rate_;
-    float deadzone_{0.02};
+    float linear_deadzone_{0.02};
+    float angular_deadzone_{0.02};
     bool was_travelling_{false};
     bool is_travelling_{false};
     bool force_extra_period_{false};
 
     // Loads from parameter server
-    float gait_period_distance_, leg_lift_height_;
+    float gait_period_distance_;
+    float gait_period_rotation_;
+    float leg_lift_height_;
+
+    /// Get the vector that is perpendicular to the clockwise.
+    Eigen::Vector2f get_perpendicular_clockwise(const Eigen::Vector2f &vec) const;
+
+    /// Get the vector that is perpendicular to the counter-clockwise.
+    Eigen::Vector2f get_perpendicular_counterclockwise(const Eigen::Vector2f &vec) const;
 };
 
 

--- a/src/gait_planner.h
+++ b/src/gait_planner.h
@@ -53,9 +53,6 @@ private:
 
     /// Get the vector that is perpendicular to the clockwise.
     Eigen::Vector2f get_perpendicular_clockwise(const Eigen::Vector2f &vec) const;
-
-    /// Get the vector that is perpendicular to the counter-clockwise.
-    Eigen::Vector2f get_perpendicular_counterclockwise(const Eigen::Vector2f &vec) const;
 };
 
 

--- a/src/gait_planner.h
+++ b/src/gait_planner.h
@@ -45,8 +45,8 @@ private:
     bool was_travelling_{false};
     bool is_travelling_{false};
     bool force_extra_period_{false};
-    bool is_translating_{true};
-    bool was_translating_{true};
+    bool is_rotating_{false};
+    bool was_rotating_{false};
 
     // Loads from parameter server
     float gait_period_distance_;

--- a/src/gait_planner.h
+++ b/src/gait_planner.h
@@ -46,6 +46,7 @@ private:
     bool is_travelling_{false};
     bool force_extra_period_{false};
     bool is_translating_{true};
+    bool was_translating_{true};
 
     // Loads from parameter server
     float gait_period_distance_;

--- a/src/hexapod_model.cpp
+++ b/src/hexapod_model.cpp
@@ -137,8 +137,7 @@ hexapod_msgs::FeetPositions HexapodModel::get_feet_positions() const {
 }
 
 hexapod_msgs::FeetPositions HexapodModel::get_feet_positions_in_body_frame() const {
-    Matrix3f body_rot_mat = get_body_rot_mat();
-    Matrix3f body_rot_mat_t = body_rot_mat.transpose();
+    Matrix3f body_rot_mat_t = get_body_rot_mat().transpose();
     Vector3f body_position_in_global(body_.position.x, body_.position.y, body_.position.z);
 
     hexapod_msgs::FeetPositions feet_positions_in_body_frame;

--- a/src/hexapod_model.cpp
+++ b/src/hexapod_model.cpp
@@ -83,6 +83,14 @@ void HexapodModel::set_body_orientation(float pitch, float yaw, float roll) {
     body_.orientation.roll = roll;
 }
 
+void HexapodModel::set_body_roll(float roll) {
+    body_.orientation.roll = roll;
+}
+
+float HexapodModel::get_body_roll() const {
+    return body_.orientation.roll;
+}
+
 void HexapodModel::set_body_position(float x, float y, float z) {
     body_.position.x = x;
     body_.position.y = y;

--- a/src/hexapod_model.cpp
+++ b/src/hexapod_model.cpp
@@ -211,6 +211,7 @@ Matrix3f HexapodModel::get_body_rot_mat() const {
 }
 
 Matrix3f HexapodModel::euler_angles_to_rotation_matrix(float roll, float yaw, float pitch) const {
+    // TODO: Might be an issue here with axis
     AngleAxisf rollAngle(roll, Vector3f::UnitZ());
     AngleAxisf yawAngle(yaw, Vector3f::UnitY());
     AngleAxisf pitchAngle(pitch, Vector3f::UnitX());

--- a/src/hexapod_model.cpp
+++ b/src/hexapod_model.cpp
@@ -128,6 +128,26 @@ hexapod_msgs::FeetPositions HexapodModel::get_feet_positions() const {
     return feet_positions_;
 }
 
+hexapod_msgs::FeetPositions HexapodModel::get_feet_positions_in_body_frame() const {
+    Matrix3f body_rot_mat = get_body_rot_mat();
+    Matrix3f body_rot_mat_t = body_rot_mat.transpose();
+    Vector3f body_position_in_global(body_.position.x, body_.position.y, body_.position.z);
+
+    hexapod_msgs::FeetPositions feet_positions_in_body_frame;
+    for (int i = 0; i < 6; i++) {
+        Vector3f foot_position_in_global_position(
+            feet_positions_.foot[i].x,
+            feet_positions_.foot[i].y,
+            feet_positions_.foot[i].z);
+        Vector3f foot_position_in_local_position = body_rot_mat_t * (foot_position_in_global_position - body_position_in_global);
+        feet_positions_in_body_frame.foot[i].x = foot_position_in_local_position[0];
+        feet_positions_in_body_frame.foot[i].y = foot_position_in_local_position[1];
+        feet_positions_in_body_frame.foot[i].z = foot_position_in_local_position[2];
+    }
+
+    return feet_positions_in_body_frame;
+}
+
 hexapod_msgs::FeetPositions HexapodModel::get_initial_feet_positions_in_body_frame() const {
     return initial_feet_positions_;
 }

--- a/src/hexapod_model.h
+++ b/src/hexapod_model.h
@@ -55,6 +55,14 @@ public:
     /// \param roll
     void set_body_orientation(float pitch, float yaw, float roll);
 
+    /// Sets the roll of the body.
+    /// \param roll
+    void set_body_roll(float roll);
+
+    /// Gets the roll of the body.
+    /// \return The current orientation roll of the body.
+    float get_body_roll() const;
+
     /// Sets the position of the body.
     /// \param x
     /// \param y

--- a/src/hexapod_model.h
+++ b/src/hexapod_model.h
@@ -95,6 +95,10 @@ public:
     /// \return The FeetPositions message.
     hexapod_msgs::FeetPositions get_feet_positions() const;
 
+    /// Gets the feet positions in body frame coordinates.
+    /// \return The FeetPositions message.
+    hexapod_msgs::FeetPositions get_feet_positions_in_body_frame() const;
+
     /// Gets the initial feet positions in the body frame coordinates
     /// \return The FeetPositions message.
     hexapod_msgs::FeetPositions get_initial_feet_positions_in_body_frame() const;

--- a/src/kinematics.cpp
+++ b/src/kinematics.cpp
@@ -11,7 +11,7 @@
 
 using namespace Eigen;
 
-Kinematics::Kinematics(std::shared_ptr<HexapodModel> model) : hexapod_model_(model){
+Kinematics::Kinematics(std::shared_ptr <HexapodModel> model) : hexapod_model_(model) {
 }
 
 hexapod_msgs::LegsJoints Kinematics::body_feet_config_to_legs_joints() {
@@ -35,24 +35,35 @@ hexapod_msgs::LegsJoints Kinematics::body_feet_config_to_legs_joints() {
     for (int i = 0; i < feet_positions.foot.size(); i++) {
         // TODO: Check if feet position is reachable.
         Vector3f body_origin_to_coxa_joint_in_local = hexapod_model_->get_center_to_coxa(i);
-        Vector3f global_origin_to_feet_ground_contact_point(feet_positions.foot[i].x, feet_positions.foot[i].y, feet_positions.foot[i].z);
+        Vector3f global_origin_to_feet_ground_contact_point(feet_positions.foot[i].x, feet_positions.foot[i].y,
+                                                            feet_positions.foot[i].z);
 
-        Vector3f feet_ground_contact_point_to_coxa = global_origin_to_body_origin + (body_rot_mat * body_origin_to_coxa_joint_in_local) - global_origin_to_feet_ground_contact_point;
+        Vector3f feet_ground_contact_point_to_coxa =
+                global_origin_to_body_origin + (body_rot_mat * body_origin_to_coxa_joint_in_local) -
+                global_origin_to_feet_ground_contact_point;
         float coxa_angle_rad = atan(feet_ground_contact_point_to_coxa[1] / feet_ground_contact_point_to_coxa[0]);
 
         int leg_dir = i <= 2 ? -1 : 1;
         Vector3f body_origin_to_femur_joint_in_local(
-            body_origin_to_coxa_joint_in_local[0] + (leg_dir * coxa_length * cos(coxa_angle_rad)),
-            body_origin_to_coxa_joint_in_local[1] + (leg_dir * coxa_length * sin(coxa_angle_rad)),
-            body_origin_to_coxa_joint_in_local[2]);
+                body_origin_to_coxa_joint_in_local[0] + (leg_dir * coxa_length * cos(coxa_angle_rad)),
+                body_origin_to_coxa_joint_in_local[1] + (leg_dir * coxa_length * sin(coxa_angle_rad)),
+                body_origin_to_coxa_joint_in_local[2]);
 
-        Vector3f feet_ground_contact_point_to_femur = global_origin_to_body_origin + (body_rot_mat * body_origin_to_femur_joint_in_local) - global_origin_to_feet_ground_contact_point;
+        Vector3f feet_ground_contact_point_to_femur =
+                global_origin_to_body_origin + (body_rot_mat * body_origin_to_femur_joint_in_local) -
+                global_origin_to_feet_ground_contact_point;
 
-        float rho_angle = atan(feet_ground_contact_point_to_femur[2] / sqrt(pow(feet_ground_contact_point_to_femur[0], 2) + pow(feet_ground_contact_point_to_femur[1], 2)));
-        float phi_angle = asin((feet_ground_contact_point_to_femur[2] - feet_ground_contact_point_to_coxa[2])/ coxa_length);
+        float rho_angle = atan(feet_ground_contact_point_to_femur[2] /
+                               sqrt(pow(feet_ground_contact_point_to_femur[0], 2) +
+                                    pow(feet_ground_contact_point_to_femur[1], 2)));
+        float phi_angle = asin(
+                (feet_ground_contact_point_to_femur[2] - feet_ground_contact_point_to_coxa[2]) / coxa_length);
 
-        float femur_angle_rad = acos((pow(femur_length, 2) + feet_ground_contact_point_to_femur.squaredNorm() - pow(tibia_length, 2)) / (2.f * femur_length * feet_ground_contact_point_to_femur.norm())) - (rho_angle + phi_angle);
-        float tibia_angle_rad = M_PI_2 - acos((pow(femur_length, 2) - feet_ground_contact_point_to_femur.squaredNorm() + pow(tibia_length, 2)) / (2.f * femur_length * tibia_length));
+        float femur_angle_rad =
+                acos((pow(femur_length, 2) + feet_ground_contact_point_to_femur.squaredNorm() - pow(tibia_length, 2)) /
+                     (2.f * femur_length * feet_ground_contact_point_to_femur.norm())) - (rho_angle + phi_angle);
+        float tibia_angle_rad = M_PI_2 - acos((pow(femur_length, 2) - feet_ground_contact_point_to_femur.squaredNorm() +
+                                               pow(tibia_length, 2)) / (2.f * femur_length * tibia_length));
 
         switch (i) {
             case 0:


### PR DESCRIPTION
Adds rotations movement but does not combine the translation and rotation movements together. Rotation movements will overwrite translation movements if any are detected.